### PR TITLE
Fixed the incompatibility with newer versions of Composer

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -14,7 +14,7 @@ namespace Qaraqter\QuestionnaireBundle\Composer;
 use Symfony\Component\ClassLoader\ClassCollectionLoader;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\PhpExecutableFinder;
-use Composer\Script\CommandEvent;
+use Composer\Script\Event;
 use Sensio\Bundle\DistributionBundle\Composer\ScriptHandler as SensioScriptHandler;
 
 class ScriptHandler extends SensioScriptHandler
@@ -22,9 +22,9 @@ class ScriptHandler extends SensioScriptHandler
     /**
      * Installs questionnaire assets in QaraqterQuestionnaireBundle.
      *
-     * @param $event CommandEvent A instance
+     * @param $event Event A instance
      */
-    public static function installAssets(CommandEvent $event)
+    public static function installAssets(Event $event)
     {
         $options = self::getOptions($event);
         $appDir = $options['symfony-app-dir'];
@@ -32,3 +32,4 @@ class ScriptHandler extends SensioScriptHandler
         static::executeCommand($event, $appDir, 'questionnaire:assets:install');
     }
 }
+


### PR DESCRIPTION
### What

When running `composer install` on the PCS project, Composer will throw this exception:

> [ErrorException]                                                                                                                                                                                                                           
> Declaration of Qaraqter\QuestionnaireBundle\Composer\ScriptHandler::installAssets(Composer\Script\CommandEvent $event) should be compatible with Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::installAssets(Composer\Script\Event $event)

This PR fixes that.

The [documentation](https://getcomposer.org/doc/articles/scripts.md#event-classes) states that a Event is always provided as the first argument but this might have changed in the last releases of composer because I believe that this used to work before.

### How to test

1. Remove `vendor/` from the PCS project
1. Now run `composer install`
1. See that it fails
1. Apply the change from this PR manually: `wget -O vendor/qaraqter/questionnaire-bundle/Composer/ScriptHandler.php https://raw.githubusercontent.com/eXistenZNL/QuestionnaireBundle/3817e413b0481dcfb599d24f275eee3c6fecada7/Composer/ScriptHandler.php`
1. Now run `composer install` again
1. See that installation now works

### Ticket

This issue was discovered during https://enrise.atlassian.net/browse/PCS-29